### PR TITLE
Update regexp due to changes in stylint

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,7 +20,7 @@ class Stylint(NodeLinter):
     syntax = 'stylus'
     cmd = 'stylint @ *'
     executable = 'stylint'
-    version_requirement = '>= 1.5.6, < 1.6.0'
+    version_requirement = '>= 1.5.0, < 1.6.0'
     regex = r'''(?xi)
         # Comments show example output for each line of a Stylint warning
         # /path/to/file/example.styl

--- a/linter.py
+++ b/linter.py
@@ -6,7 +6,6 @@
 # Copyright (c) 2015 Jack Brewer
 #
 # License: MIT
-#
 
 """This module exports the Stylint plugin class."""
 
@@ -21,17 +20,13 @@ class Stylint(NodeLinter):
     syntax = 'stylus'
     cmd = 'stylint @ *'
     executable = 'stylint'
-    version_requirement = '>= 0.9.3'
+    version_requirement = '>= 1.5.6, < 1.6.0'
     regex = r'''(?xi)
         # Comments show example output for each line of a Stylint warning
-        # 'Near' can contain trailing whitespace, which we avoid capturing
-
-        # Warning:  commas must be followed by a space for readability
-        ^((?P<warning>warning)|(?P<error>Error)):\s*(?P<message>.+)$\s*
-        # File: /path/to/file/example.styl
+        # /path/to/file/example.styl
         ^.*$\s*
-        # Line: 46: color rgba(0,0,0,.5)
-        ^Line:\s*(?P<line>\d+):\s*(?P<near>.*\S)
+        # 177:24 colors warning hexidecimal color should be a variable
+        (?P<line>\d+):(?P<near>\d+)\s*\w+\s*((?P<warning>warning)|(?P<error>error))\s*(?P<message>.+)$\s*
     '''
     multiline = True
     error_stream = util.STREAM_STDOUT


### PR DESCRIPTION
Hi, stylint default reporter output was changed in 1.5.0 version.
https://github.com/rossPatton/stylint/blob/master/changelog.md#150

Example of reporter output now:
![reporter-output](https://cloud.githubusercontent.com/assets/2514038/16443978/5d3ad7c2-3de4-11e6-9e3d-cbff6f37ca6c.png)

In this regard, I have changed the regular expression and `version_requirement` attribute
