### PR TITLE
Make "near" group optional in regex

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,7 @@ class Stylint(NodeLinter):
         # /path/to/file/example.styl
         ^.*$\s*
         # 177:24 colors warning hexidecimal color should be a variable
-        ^(?P<line>\d+):(?P<near>\d+)\s*\w+\s*((?P<warning>warning)|(?P<error>error))\s*(?P<message>.+)$\s*
+        ^(?P<line>\d+):?(?P<near>\d+)?\s*\w+\s*((?P<warning>warning)|(?P<error>error))\s*(?P<message>.+)$\s*
     '''
     multiline = True
     error_stream = util.STREAM_STDOUT


### PR DESCRIPTION
Some errors output with a column number. For these, the `near` group should match.

```
1:2 semicolons error unnecessary semicolon found
```

But some won't. For these, the `near` match should be optional.

```
1 sortOrder error prefer alphabetical when sorting properties
```