### PR TITLE
Update regex and allow linting Vue component files

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,8 @@ class Stylint(NodeLinter):
     """Provides an interface to stylint."""
 
     npm_name = 'stylint'
-    syntax = 'stylus'
+    syntax = ('stylus', 'vue')
+    selectors = {'vue': 'source.stylus.embedded.html'}
     cmd = 'stylint @ *'
     executable = 'stylint'
     version_requirement = '>= 1.5.0'

--- a/linter.py
+++ b/linter.py
@@ -26,7 +26,7 @@ class Stylint(NodeLinter):
         # /path/to/file/example.styl
         ^.*$\s*
         # 177:24 colors warning hexidecimal color should be a variable
-        ^(?P<line>\d+):?(?P<near>\d+)?\s*\w+\s*((?P<warning>warning)|(?P<error>error))\s*(?P<message>.+)$\s*
+        ^(?P<line>\d+):?(?P<col>\d+)?\s*((?P<warning>warning)|(?P<error>error))\s*(?P<message>.+)$\s*
     '''
     multiline = True
     error_stream = util.STREAM_STDOUT

--- a/linter.py
+++ b/linter.py
@@ -7,7 +7,7 @@
 #
 # License: MIT
 
-"""This module exports the Stylint plugin class."""
+"""Exports the Stylint plugin class."""
 
 from SublimeLinter.lint import NodeLinter, util
 


### PR DESCRIPTION
- I updated the regex to reflect the way Stylint output is now formatted:

![screen shot 2017-12-12 at 12 32 32 am](https://user-images.githubusercontent.com/4214270/33925210-ff1ad55a-df8d-11e7-92c6-b0a3250b9c45.jpg)

- Also, renamed `near` capture group to `col` to correctly capture the column number. According to the SublimeLinter [docs](http://www.sublimelinter.com/en/latest/linter_attributes.html#regex), `near` refers to a name rather than the column number.
- Added support for linting Stylus blocks in [Vue component files](https://vuejs.org/v2/guide/single-file-components.html) via the Stylus block's scope.