### PR TITLE
Remove more deprecated code and fix new selector setting

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Stylint(NodeLinter):
 
     cmd = 'stylint @ *'
     defaults = {
-        'selector': 'source.stylus, text.html.vue, source.stylus.embedded.html',
+        'selector': 'source.stylus, source.stylus.embedded.html',
         '--ignore=,': '',
         '--warn=,': '',
         '--error=,': ''

--- a/linter.py
+++ b/linter.py
@@ -16,13 +16,9 @@ class Stylint(NodeLinter):
 
     """Provides an interface to stylint."""
 
-    npm_name = 'stylint'
-    selectors = {'vue': 'source.stylus.embedded.html'}
     cmd = 'stylint @ *'
-    executable = 'stylint'
-    version_requirement = '>= 1.5.0'
     defaults = {
-        'selector': 'source.stylus, text.html.vue',
+        'selector': 'source.stylus, text.html.vue, source.stylus.embedded.html',
         '--ignore=,': '',
         '--warn=,': '',
         '--error=,': ''


### PR DESCRIPTION
The last commit left some deprecated setting lingering and also had the wrong selector for stylus code inside vue files.