### PR TITLE
Fix deprecation warnings

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -16,7 +16,7 @@ from regex import regex
 class Stylint(NodeLinter):
     """Provides an interface to stylint."""
 
-    cmd = 'stylint @ *'
+    cmd = 'stylint ${temp_file} ${args}'
     defaults = {
         'selector': 'source.stylus, source.stylus.embedded.html',
         '--ignore=,': '',
@@ -27,4 +27,3 @@ class Stylint(NodeLinter):
     multiline = True
     error_stream = util.STREAM_STDOUT
     tempfile_suffix = 'styl'
-    config_file = ('--config', '.stylintrc', '~')


### PR DESCRIPTION
`@` and `*` symbols are deprecated.  `config_file` has been removed already. 